### PR TITLE
Login ratelimit

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -13,6 +13,7 @@ app = Flask(__name__)
 limiter = Limiter(
     get_remote_address,
     app=app,
+    default_limits=["60 per minute"],
     storage_uri="memory://",
 )
 app.secret_key = os.getenv("FLASK_SECRET_KEY", default=secrets.token_hex()).encode()

--- a/app/application.py
+++ b/app/application.py
@@ -4,10 +4,17 @@ import secrets
 import os
 import bcrypt
 from flask import Flask, session, redirect, url_for, request, render_template, abort
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 
 app = Flask(__name__)
+limiter = Limiter(
+    get_remote_address,
+    app=app,
+    storage_uri="memory://",
+)
 app.secret_key = os.getenv("FLASK_SECRET_KEY", default=secrets.token_hex()).encode()
 app.logger.setLevel(logging.INFO)
 if os.getenv("PROXY") == "true":
@@ -75,6 +82,7 @@ def index():
 
 
 @app.route("/login", methods=["GET", "POST"])
+@limiter.limit("5/minute", override_defaults=False)
 def login():
     if request.method == "POST":
         username = request.form.get("username")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.1
 bcrypt==4.2.1
 gunicorn==23.0.0
+Flask-Limiter==3.9.2


### PR DESCRIPTION
The login page now has a limit of 5 requests per minute per user, preventing brute-force attacks. The other pages all have a limit of 60 requests per minute per user to prevent DOS attacks.